### PR TITLE
Update 'Home' link text in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
             <div class="logo">Traveler</div>
             <nav>
                 <ul>
-                    <li><a href="#">ホーム</a></li>
+                    <li><a href="#">Home</a></li>
                     <li><a href="#">目的地</a></li>
                     <li><a href="#">私たちについて</a></li>
                     <li><a href="#">お問い合わせ</a></li>


### PR DESCRIPTION
The text in the navigation menu item for 'Home' was originally 'ホーム'. I've changed it to 'Home' as requested. Verified the change with grep and a Playwright test script.

Fixes #3

---
*PR created automatically by Jules for task [8961927769439451301](https://jules.google.com/task/8961927769439451301) started by @mktdev3*